### PR TITLE
Fix double tap issue on Mobile

### DIFF
--- a/src/lite-yt-embed.js
+++ b/src/lite-yt-embed.js
@@ -17,7 +17,6 @@ class LiteYTEmbed extends HTMLElement {
         // Gotta encode the untrusted value
         // https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-2---attribute-escape-before-inserting-untrusted-data-into-html-common-attributes
         this.videoId = encodeURIComponent(this.getAttribute('videoid'));
-
         /**
          * Lo, the youtube placeholder image!  (aka the thumbnail, poster image, etc)
          * There is much internet debate on the reliability of thumbnail URLs. Weak consensus is that you
@@ -38,6 +37,19 @@ class LiteYTEmbed extends HTMLElement {
         // Warm the connection for the poster image
         LiteYTEmbed.addPrefetch('preload', this.posterUrl, 'image');
         // TODO: support dynamically setting the attribute via attributeChangedCallback
+    }
+
+    fetchYoutubeAPI(cb) {
+        var tag = document.createElement('script');
+        tag.src = 'https://www.youtube.com/iframe_api';
+        tag.async = true;
+        var firstScriptTag = document.getElementsByTagName('script')[0];
+        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+        tag.onload = () => {
+            YT.ready(() => {
+                if(cb) cb();
+            })
+        };
     }
 
     connectedCallback() {
@@ -98,13 +110,31 @@ class LiteYTEmbed extends HTMLElement {
         LiteYTEmbed.preconnected = true;
     }
 
-    addIframe(){
-        const iframeHTML = `
-<iframe width="560" height="315" frameborder="0"
-  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen
-  src="https://www.youtube-nocookie.com/embed/${this.videoId}?autoplay=1"
-></iframe>`;
-        this.insertAdjacentHTML('beforeend', iframeHTML);
+    onYouTubeIframeAPIReady() {
+        const videoWrapper = document.createElement('div')
+        videoWrapper.id = this.videoId;
+        document.body.appendChild(videoWrapper);
+        this.insertAdjacentElement('beforeend', videoWrapper);
+
+        new YT.Player(videoWrapper, {
+            width: '100%',
+            videoId: this.videoId,
+            playerVars: { 'autoplay': 1, 'playsinline': 1 },
+            events: {
+                'onReady': (event) => {
+                    event.target.mute();
+                    event.target.playVideo();
+                }
+            }
+        });
+    }
+
+   addIframe(){
+        if(typeof(YT) == 'undefined' || typeof(YT.Player) == 'undefined') {
+            this.fetchYoutubeAPI(this.onYouTubeIframeAPIReady.bind(this));
+        }
+
+        // Keeping the default implementation for iframes
         this.classList.add('lyt-activated');
     }
 }


### PR DESCRIPTION
### What is done

**Fix double tap issue on Mobile**
Currently, you must to double tab a video and is very annoying for the users.

**Fetch YouTube API script on demand**
The client fetch the YouTube API Library only when the user click a placeholder video by the first time.

**It doesn't use iframes directly**
iframes are using internally through the YouTube API Library

**Keep the performance stunning**
It doesn't impact to the performance because the library is not being fetched at the same time that the page is being loaded. You can validate against the two attached reports below.

### Lighthouse
The reports are almost the same, in fact, you can see on the first screenshot that the video placeholder is being shown more faster than the previous implementation.

This is the audit related to the **new** implementation `/variants/solo`:

![Screenshot 2021-07-14 at 08 07 47](https://user-images.githubusercontent.com/2814580/125612422-7c06d6c5-4229-4b42-a3b5-5f53ad9e697e.png)

This is the audit related to the **previous** implementation `/variants/solo`:
![Screenshot 2021-07-14 at 08 11 22](https://user-images.githubusercontent.com/2814580/125612730-2b8f0775-f7d3-41e9-ac67-64d8d55c7f46.png)


